### PR TITLE
Copy only the original text

### DIFF
--- a/src/background_scripts/main.js
+++ b/src/background_scripts/main.js
@@ -71,14 +71,25 @@ function updateContextMenu ( originName, targetName ) {
 	});
 }
 
-browser.contextMenus.onClicked.addListener( ( info, tab ) => {
+browser.contextMenus.onClicked.addListener( async ( info, tab ) => {
 	if ( info.menuItemId !== 'translate-add-word-to-dictionary' || !info.selectionText ) {
 		return;
 	}
 
-	browser.storage.local.get( [ 'origin', 'target', 'originNativeName', 'targetNativeName' ] ).then( value => {
-		const word = encodeURIComponent( info.selectionText.trim() );
+	let cleanText = info.selectionText.trim();
 
+	try {
+		const response = await browser.tabs.sendMessage( tab.id, { type: 'GET_CLEAN_SELECTION' });
+
+		if ( response && typeof response === 'string' ) {
+			cleanText = response.trim();
+		}
+	} catch ( error ) {
+		// Ignore errors
+	}
+
+	browser.storage.local.get( [ 'origin', 'target', 'originNativeName', 'targetNativeName' ] ).then( value => {
+		const word = encodeURIComponent( cleanText );
 		const autoTranslate = '&autoTranslate=true';
 
 		const urlFragment = `#${value.origin}~${value.target}~${value.originNativeName}~${value.targetNativeName}`;

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -5,6 +5,42 @@ import {
 import countWord from './analyze';
 import translate from './translate';
 
+document.addEventListener( 'copy', ( event ) => {
+	const selection = window.getSelection();
+
+	if ( selection.rangeCount === 0 ) {
+		return;
+	}
+
+	const range = selection.getRangeAt( 0 );
+
+	const fragment = range.cloneContents();
+
+	const translatedElements = fragment.querySelectorAll( 'progressive-immersion-word' );
+
+	if ( translatedElements.length === 0 ) {
+		return;
+	}
+
+	event.preventDefault();
+
+	translatedElements.forEach( elem => {
+		const originalWord = elem.getAttribute( 'data-original-word' );
+		if ( originalWord ) {
+			const textNode = document.createTextNode( originalWord );
+			elem.replaceWith( textNode );
+		}
+	});
+
+	const tempDiv = document.createElement( 'div' );
+	tempDiv.appendChild( fragment );
+
+	if ( event.clipboardData ) {
+		event.clipboardData.setData( 'text/plain', tempDiv.textContent );
+		event.clipboardData.setData( 'text/html', tempDiv.innerHTML );
+	}
+});
+
 function capitalizationPermutations ( stringArray ){
 	const result = [];
 	for ( const s of stringArray ) {

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -217,3 +217,36 @@ const viewObserver = new IntersectionObserver( ( entries ) => {
 		}
 	}
 });
+
+browser.runtime.onMessage.addListener( ( msg, sender, sendResponse ) => {
+	if ( msg.type === 'GET_CLEAN_SELECTION' ) {
+		const selection = window.getSelection();
+
+		if ( !selection || selection.rangeCount === 0 ) {
+			sendResponse( '' );
+			return true;
+		}
+
+		const range = selection.getRangeAt( 0 );
+
+		const fragment = range.cloneContents();
+		const translatedElements = fragment.querySelectorAll( 'progressive-immersion-word' );
+
+		if ( translatedElements.length === 0 ) {
+			sendResponse( selection.toString() );
+			return true;
+		}
+
+		translatedElements.forEach( elem => {
+			const originalWord = elem.getAttribute( 'data-original-word' );
+			if ( originalWord ) {
+				const textNode = document.createTextNode( originalWord );
+				elem.replaceWith( textNode );
+			}
+		});
+
+		sendResponse( fragment.textContent );
+	}
+
+	return true;
+});


### PR DESCRIPTION
Currently when you copy from a website and some words were changed by the extension, the copied sentence will include the changed words.
This can be very annoying when using the extension and may prompt some users to turn it off if they need to copy something.

This change makes sure that when you copy, it will always be the original text.